### PR TITLE
Basic auth support

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -100,22 +100,22 @@ document.addEventListener('DOMContentLoaded', function() {
         setTimeout(() => { warning.classList.add('hidden'); }, 3000);
         return;
       }
-	  
-	    const urlObj = new URL(apiUrl);
+    
+      const urlObj = new URL(apiUrl);
       const username = urlObj.username;
       const password = urlObj.password;
-	  
+    
       // Remove username and password from url
       urlObj.username = '';
       urlObj.password = '';
-	
+  
       const fullUrl = urlObj.toString() + topic;
-	  
+    
       const headers = new Headers();
-	    if(username && password) {
-	      const credentials = btoa(`${username}:${password}`);
-		    headers.set('Authorization', `Basic ${credentials}`);
-	    }
+      if(username && password) {
+        const credentials = btoa(`${username}:${password}`);
+        headers.set('Authorization', `Basic ${credentials}`);
+      }
       if (accessToken) {
         headers.set('Authorization', `Bearer ${accessToken}`);
       }

--- a/popup.js
+++ b/popup.js
@@ -100,12 +100,24 @@ document.addEventListener('DOMContentLoaded', function() {
         setTimeout(() => { warning.classList.add('hidden'); }, 3000);
         return;
       }
-
-      const fullUrl = apiUrl + '/' + topic;
-
+	  
+	    const urlObj = new URL(apiUrl);
+      const username = urlObj.username;
+      const password = urlObj.password;
+	  
+      // Remove username and password from url
+      urlObj.username = '';
+      urlObj.password = '';
+	
+      const fullUrl = urlObj.toString() + topic;
+	  
       const headers = new Headers();
+	    if(username && password) {
+	      const credentials = btoa(`${username}:${password}`);
+		    headers.set('Authorization', `Basic ${credentials}`);
+	    }
       if (accessToken) {
-        headers.set('Authorization', 'Bearer ' + accessToken);
+        headers.set('Authorization', `Bearer ${accessToken}`);
       }
 
       fetch(fullUrl, {
@@ -114,7 +126,7 @@ document.addEventListener('DOMContentLoaded', function() {
         body: message
       }).then(response => {
         if (!response.ok) {
-          console.error("Failed to send message:", response);
+          console.error(`Failed to send message: ${response.status}`);
           status.textContent = "Failed to send message.";
           status.style.color = 'red';
         } else {


### PR DESCRIPTION
This PR enables the send_to_ntfy_extension to work with ntfy.sh secured with Basic Authentication by adding support for Basic Auth credentials in the URL schema. 

What was done:
Enhanced the URL schema parsing to extract Basic Auth credentials (e.g., https://user:password@ntfy.sh/topic).
Automatically encodes these credentials and includes them in the Authorization header for HTTP requests.
This update allows seamless and secure interaction with ntfy.sh using Basic Authentication.