### PR TITLE
feat(prefillEnabled) add prefill & code refactors for async local storage and hoisted functions/global variables

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -89,6 +89,13 @@
       margin: 10px 0;
       text-align: center;
     }
+
+    .checkbox-container {
+      display: flex;
+      align-items: center;
+      white-space: nowrap; /* Prevent text from wrapping */
+      margin-top: 5px;
+    }
   </style>
 </head>
 <body>
@@ -97,9 +104,9 @@
     <select id="topic-select"></select>
   </div>
   <div class="container">
-    <button id="send">Send to ntfy</button>    
-	<span class="open-url" title="Open ntfy URL">&#128279;</span>
-    <span class="settings">&#9881;</span>
+    <button id="send">Send to ntfy</button>
+    <span class="open-url" title="Open ntfy URL">&#128279;</span>
+    <span class="settings" id="settings-icon" title="Settings">&#9881;</span>
   </div>
   <div id="warning" class="hidden">Please configure ntfy settings first.</div>
   <div id="status"></div>
@@ -110,6 +117,10 @@
     <input type="password" id="token">
     <label for="topics">Topics (comma separated):</label>
     <input type="text" id="topics">
+    <div class="checkbox-container">
+      <label for="prefill">Enable Prefill with URL:</label>
+      <input type="checkbox" id="prefill">
+    </div>
     <div style="margin-top: 10px;">
       <button id="save">Save Configuration</button>
     </div>

--- a/service_worker.js
+++ b/service_worker.js
@@ -1,7 +1,7 @@
 chrome.runtime.onInstalled.addListener(function() {
-  chrome.storage.sync.get(['topic', 'apiUrl', 'accessToken'], function(items) {
+  chrome.storage.sync.get(['topic', 'apiUrl', 'accessToken', 'prefillEnabled'], function(items) {
     if (!items.topic && !items.apiUrl && !items.accessToken) {
-      chrome.storage.sync.set({ topic: '', apiUrl: '', accessToken: '' }, function() {
+      chrome.storage.sync.set({ topic: '', apiUrl: '', accessToken: '', prefillEnabled: true }, function() {
         console.log("The ntfy configuration is set to empty.");
       });
     }


### PR DESCRIPTION
Added Enable Prefill with Url ~~and Enable Dark Mode~~ Options / Checkboxes: 
- for more customizability and quality of life improvements
- refactored code so it's more extensible and reusable

| Feature / Update | Description |
|---|---|
| Enable Prefill with URL Option | - Checkbox allowing users to enable/disable adding the page URL to the message. <br> - Useful for sending notifications without the URL. (Saves to storage) |
| **Prefill Functionality** | - Unchecking/checking the checkbox and saving the config updates the message in real-time. <br> - Removes or appends the page URL to the message beginning. <br> - Prevents duplicate removals/additions if the message is edited before saving config. |
| ~~**Enable Dark Mode**~~ | ~~- Checkbox allowing users to enable/disable dark mode for the extension's UI. (Saves to storage)~~ |
| Refactored popup.js | - Hoisted functions and global variables for execution before declaration. <br> - Enables asynchronous functionality by retrieving data from storage once. <br> - Previously called `chrome.storage.sync.get()` three times, now called once onload and stores values in global variables. |
| Modularized Functions | - Improved extensibility by modularizing functions. <br> - Allows independent function calls (e.g., `getConfigs`, `saveConfig`, `updateUI`, `showStatus`, `showWarning`, etc.) from anywhere. <br> - Facilitates future refactoring into separate files. |
| Retained Functionality | - All previous functionalities are maintained and tested. |

##

| Screenshot | Demo |
|---|---|
| <a href="https://github.com/user-attachments/assets/96021502-ccb8-41b4-8af5-a6d5a6d31aa1" target="_blank">![](https://github.com/user-attachments/assets/96021502-ccb8-41b4-8af5-a6d5a6d31aa1)</a> | <a href="https://github.com/user-attachments/assets/10e70aa5-65d3-4494-bb5a-0eccb7618002" target="_blank">![](https://github.com/user-attachments/assets/10e70aa5-65d3-4494-bb5a-0eccb7618002)</a> |

### Revised
- removed Enable dark mode option
![image](https://github.com/user-attachments/assets/d80e3363-4e03-4733-949c-a54806b75954)